### PR TITLE
Fix for customized ":listchars" ignored by selection

### DIFF
--- a/colors/itzikode.vim
+++ b/colors/itzikode.vim
@@ -157,7 +157,7 @@ call <sid>hi('CursorLineNr', s:cdPopupFront, s:cdBack,               'none',    
 call <sid>hi('MatchParen',   s:cdNone,       s:cdCursorDark,         'none',      {})
 call <sid>hi('ModeMsg',      s:cdFront,      s:cdLeftDark,           'none',      {})
 call <sid>hi('MoreMsg',      s:cdFront,      s:cdLeftDark,           'none',      {})
-call <sid>hi('NonText',      s:cdLineNumber, s:cdBack,               'none',      {})
+call <sid>hi('NonText',      s:cdLineNumber, s:cdNone,               'none',      {})
 call <sid>hi('Pmenu',        s:cdPopupFront, s:cdPopupBack,          'none',      {})
 call <sid>hi('PmenuSel',     s:cdPopupFront, s:cdPopupHighlightBlue, 'none',      {})
 call <sid>hi('PmenuSbar',    {},             s:cdPopupHighlightGray, 'none',      {})


### PR DESCRIPTION
# Closes #1
![image]()


### Before
<img width='876' alt='image' src='https://user-images.githubusercontent.com/18270061/162525616-b88af8b6-669e-4695-8b1c-c091331e615c.png'>

### After
<img width='876' alt='image' src='https://user-images.githubusercontent.com/18270061/162525826-118dd3af-ca2c-4ce2-8adb-782f596a212d.png'>